### PR TITLE
Fix various compile issues under linux.

### DIFF
--- a/src/qanConnector.cpp
+++ b/src/qanConnector.cpp
@@ -113,7 +113,7 @@ void    Connector::connectorReleased(QQuickItem* target) noexcept
     const auto dstEdgeItem = qobject_cast<qan::EdgeItem*>(target);
 
     const auto srcPortItem = _sourcePort;
-    const auto srcNode = _sourceNode ? _sourceNode :
+    const auto srcNode = _sourceNode ? _sourceNode.data() :
                                        _sourcePort ? _sourcePort->getNode() : nullptr;
     const auto dstNode = dstNodeItem ? dstNodeItem->getNode() :
                                        dstPortItem ? dstPortItem->getNode() : nullptr;

--- a/src/qanUtils.h
+++ b/src/qanUtils.h
@@ -41,12 +41,7 @@
 #include <random>
 #include <exception>
 
-// GTpo headers
-#include <GTpo>
-
-// QuickQanava headers
-#include "./qanGraphConfig.h"
-#include "./qanGraph.h"
+#include <QString>
 
 //! Main QuickQanava namespace
 namespace qan { // ::qan


### PR DESCRIPTION
- Fix circular dep error in qanUtils.h
- Fix ambiguous semantics in qanConnector.cpp

The above errors happended under linux with clang and c++14.
Win10 with default project settings had no errors.