### PR TITLE
Make it compile with GCC 4.9 (Android builds)

### DIFF
--- a/GTpo/src/gtpoGenGraph.h
+++ b/GTpo/src/gtpoGenGraph.h
@@ -385,10 +385,10 @@ public:
      */
     auto            groupNode( WeakGroup weakGroup, WeakNode weakNode ) noexcept(false) -> void
     {
-        auto group{ weakGroup.lock() };
+        auto group = weakGroup.lock();
         gtpo::assert_throw( group != nullptr, "gtpo::GenGroup<>::groupNode(): Error: trying to insert a node into an expired group." );
 
-        auto node{ weakNode.lock() };
+        auto node = weakNode.lock();
         gtpo::assert_throw( node != nullptr, "gtpo::GenGroup<>::groupNode(): Error: trying to insert an expired node in group." );
 
         node->setGroup( weakGroup );
@@ -418,10 +418,10 @@ public:
      */
     auto            ungroupNode( WeakGroup weakGroup, WeakNode weakNode ) noexcept(false) -> void
     {
-        auto group{ weakGroup.lock() };
+        auto group = weakGroup.lock();
         gtpo::assert_throw( group != nullptr, "gtpo::GenGroup<>::ungroupNode(): Error: trying to ungroup from an expired group." );
 
-        auto node{ weakNode.lock() };
+        auto node = weakNode.lock();
         gtpo::assert_throw( node != nullptr, "gtpo::GenGroup<>::ungroupNode(): Error: trying to ungroup an expired node from a group." );
 
         gtpo::assert_throw( node->getGroup().lock() == group, "gtpo::GenGroup<>::ungroupNode(): Error: trying to ungroup a node that is not part of group." );

--- a/GTpo/src/gtpoGenGraph.hpp
+++ b/GTpo/src/gtpoGenGraph.hpp
@@ -218,7 +218,7 @@ template < class Config >
 auto    GenGraph< Config >::insertEdge( SharedEdge edge ) -> WeakEdge
 {
     assert_throw( edge != nullptr );
-    auto source{ edge->getSrc().lock() };
+    auto source = edge->getSrc().lock();
     if ( source == nullptr ||
          ( edge->getDst().expired() && edge->getHDst().expired() ) )
         throw gtpo::bad_topology_error( "gtpo::GenGraph<>::insertEdge(): Error: Either source and/or destination nodes are expired." );
@@ -227,17 +227,17 @@ auto    GenGraph< Config >::insertEdge( SharedEdge edge ) -> WeakEdge
     Config::template container_adapter<WeakEdgesSearch>::insert( edge, _edgesSearch );
     try {
         source->addOutEdge( edge );
-        auto destination{ edge->getDst().lock() };
+        auto destination = edge->getDst().lock();
         if ( destination != nullptr ) {
             destination->addInEdge( edge );
             if ( source.get() != destination.get() ) // If edge define is a trivial circuit, do not remove destination from root nodes
                 Config::template container_adapter<WeakNodes>::remove( destination, _rootNodes );    // Otherwise destination is no longer a root node
         } else {
-            auto hDestination{ edge->getHDst().lock() };
+            auto hDestination = edge->getHDst().lock();
             if ( hDestination != nullptr )
                 hDestination->addInHEdge( edge );
         }
-        auto weakEdge{WeakEdge{edge}};
+        auto weakEdge = WeakEdge(edge);
         BehaviourableBase::notifyEdgeInserted( weakEdge );
     } catch ( ... ) {
         throw gtpo::bad_topology_error( "gtpo::GenGraph<>::createEdge(): Insertion of edge failed, source or destination nodes topology can't be modified." );
@@ -297,7 +297,7 @@ void    GenGraph< Config >::removeEdge( WeakEdge edge )
 
     // If there is in hyper edges, remove them since their destination edge is beeing destroyed
     if ( edgePtr->getInHDegree() > 0 ) {
-        auto& inHEdges{ edgePtr->getInHEdges() };    // Make a deep copy of in hyper edges
+        auto& inHEdges = edgePtr->getInHEdges();    // Make a deep copy of in hyper edges
         for ( auto& inHEdge : inHEdges )
             removeEdge( inHEdge );
     }

--- a/src/qanGrid.cpp
+++ b/src/qanGrid.cpp
@@ -33,7 +33,8 @@
 //-----------------------------------------------------------------------------
 
 // Std headers
-#include <cmath>        // std::round
+//#include <cmath>        // std::round
+#include <math.h>        // std::round
 #include <iostream>
 
 // Qt headers
@@ -213,8 +214,8 @@ bool    PointGrid::updateGrid(const QRectF& viewRect,
     //qDebug() << "rectified.bottomRight=" << rectified.bottomRight();
 
     // FIXME: check that the rounding do not generate the graphics glitchs...
-    const unsigned int numPointsX = static_cast<unsigned int>(std::round(rectified.width() / adaptativeScale));
-    const unsigned int numPointsY = static_cast<unsigned int>(std::round(rectified.height() / adaptativeScale));
+    const unsigned int numPointsX = static_cast<unsigned int>(round(rectified.width() / adaptativeScale));
+    const unsigned int numPointsY = static_cast<unsigned int>(round(rectified.height() / adaptativeScale));
 
     // Update points cache size
     const unsigned int pointsCount = static_cast<unsigned int>(numPointsX * numPointsY);
@@ -324,8 +325,8 @@ bool    LineGrid::updateGrid( const QRectF& viewRect,
     //qDebug() << "rectified.topLeft=" << rectified.topLeft();
     //qDebug() << "rectified.bottomRight=" << rectified.bottomRight();
 
-    const unsigned int numLinesX = static_cast<unsigned int>(std::round(rectified.width() / adaptativeScale));
-    const unsigned int numLinesY = static_cast<unsigned int>(std::round(rectified.height() / adaptativeScale));
+    const unsigned int numLinesX = static_cast<unsigned int>(round(rectified.width() / adaptativeScale));
+    const unsigned int numLinesY = static_cast<unsigned int>(round(rectified.height() / adaptativeScale));
 
     // Update points cache size
     const unsigned int linesCount = numLinesX + numLinesY;


### PR DESCRIPTION
It fails with template deduction errors.
Consider not using `std::initializer_list` so hard.

With these changes it runs on Android just fine, considering it was not meant for HiDPI and touch input.