### PR TITLE
Fixes for CMake build on Windows target

### DIFF
--- a/samples/connector/CMakeLists.txt
+++ b/samples/connector/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(Qt5Qml)
 find_package(Qt5QuickControls2 REQUIRED)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-qt5_wrap_cpp(source_files, header_files)
+#qt5_wrap_cpp(source_files, header_files)
 qt5_add_resources(RESOURCES connector.qrc)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_QML_DEBUG>)
 
@@ -32,4 +32,10 @@ add_executable(sample_connector ${source_files} ${RESOURCES})
 target_include_directories(sample_connector PUBLIC QuickQanava Qt5::QuickControls2)
 target_link_libraries(sample_connector QuickQanava QuickContainers Qt5::Core Qt5::Gui Qt5::QuickControls2)
 
-
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+    add_custom_command(TARGET sample_connector POST_BUILD
+        COMMAND ${WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE:sample_connector> $<$<CONFIG:Debug>:--pdb>)
+    add_custom_command(TARGET sample_connector POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QuickQanava> $<TARGET_FILE_DIR:sample_connector>)
+endif()

--- a/samples/connector/connector.qml
+++ b/samples/connector/connector.qml
@@ -28,6 +28,7 @@ import QtQuick                   2.8
 import QtQuick.Controls          2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts           1.3
+import QtQuick.Shapes            1.0
 
 import QuickQanava 2.0 as Qan
 import "qrc:/QuickQanava" as Qan

--- a/samples/dataflow/CMakeLists.txt
+++ b/samples/dataflow/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(Qt5Qml)
 find_package(Qt5QuickControls2 REQUIRED)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-qt5_wrap_cpp(source_files, header_files)
+#qt5_wrap_cpp(source_files, header_files)
 qt5_add_resources(RESOURCES dataflow.qrc)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_QML_DEBUG>)
 
@@ -34,5 +34,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(sample_dataflow ${source_files} ${RESOURCES})
 target_include_directories(sample_dataflow PUBLIC QuickQanava Qt5::QuickControls2)
 target_link_libraries(sample_dataflow QuickQanava QuickContainers Qt5::Core Qt5::Gui Qt5::QuickControls2)
+
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+    add_custom_command(TARGET sample_dataflow POST_BUILD
+        COMMAND ${WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE:sample_dataflow> $<$<CONFIG:Debug>:--pdb>)
+    add_custom_command(TARGET sample_dataflow POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QuickQanava> $<TARGET_FILE_DIR:sample_dataflow>)
+endif()
+
 
 

--- a/samples/dataflow/dataflow.qml
+++ b/samples/dataflow/dataflow.qml
@@ -28,6 +28,7 @@ import QtQuick                   2.8
 import QtQuick.Controls          2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts           1.3
+import QtQuick.Shapes            1.0
 
 import QuickQanava          2.0 as Qan
 import QuickQanava.Samples  1.0

--- a/samples/edges/CMakeLists.txt
+++ b/samples/edges/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Qt5Qml)
 find_package(Qt5QuickControls2 REQUIRED)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOMOC ON)
-qt5_wrap_cpp(source_files, header_files)
+#qt5_wrap_cpp(source_files, header_files)
 qt5_add_resources(RESOURCES edges.qrc)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories( ${Qt5Quick_INCLUDE_DIRS} )
@@ -31,4 +31,13 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_
 add_executable(sample_edges ${source_files} ${RESOURCES})
 target_include_directories(sample_edges PUBLIC QuickQanava Qt5::QuickControls2)
 target_link_libraries(sample_edges QuickQanava QuickContainers Qt5::Core Qt5::Gui Qt5::QuickControls2)
+
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+    add_custom_command(TARGET sample_edges POST_BUILD
+        COMMAND ${WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE:sample_edges> $<$<CONFIG:Debug>:--pdb>)
+    add_custom_command(TARGET sample_edges POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QuickQanava> $<TARGET_FILE_DIR:sample_edges>)
+endif()
+
 

--- a/samples/edges/edges.qml
+++ b/samples/edges/edges.qml
@@ -29,6 +29,7 @@ import QtQuick.Controls          2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts           1.3
 import QtQuick.Dialogs           1.2
+import QtQuick.Shapes            1.0
 
 import QuickQanava          2.0 as Qan
 import "qrc:/QuickQanava"   as Qan

--- a/samples/groups/CMakeLists.txt
+++ b/samples/groups/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Qt5Qml)
 find_package(Qt5QuickControls2 REQUIRED)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-qt5_wrap_cpp(source_files, header_files)
+#qt5_wrap_cpp(source_files, header_files)
 qt5_add_resources(RESOURCES groups.qrc)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_QML_DEBUG>)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -32,5 +32,13 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(sample_groups ${source_files} ${RESOURCES})
 target_include_directories(sample_groups PUBLIC QuickQanava Qt5::QuickControls2)
 target_link_libraries(sample_groups QuickQanava QuickContainers Qt5::Core Qt5::Gui Qt5::QuickControls2)
+
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+    add_custom_command(TARGET sample_groups POST_BUILD
+        COMMAND ${WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE:sample_groups> $<$<CONFIG:Debug>:--pdb>)
+    add_custom_command(TARGET sample_groups POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QuickQanava> $<TARGET_FILE_DIR:sample_groups>)
+endif()
 
 

--- a/samples/groups/groups.qml
+++ b/samples/groups/groups.qml
@@ -28,6 +28,7 @@ import QtQuick                   2.8
 import QtQuick.Controls          2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts           1.3
+import QtQuick.Shapes            1.0
 
 import QuickQanava 2.0 as Qan
 import "qrc:/QuickQanava" as Qan

--- a/samples/navigable/CMakeLists.txt
+++ b/samples/navigable/CMakeLists.txt
@@ -25,7 +25,7 @@ set( source_files
 set (header_files )
 
 set(CMAKE_AUTORCC ON)
-qt5_wrap_cpp(source_files, header_files)
+#qt5_wrap_cpp(source_files, header_files)
 qt5_add_resources(RESOURCES navigable.qrc)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories( ${Qt5Quick_INCLUDE_DIRS} )
@@ -35,5 +35,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(sample_navigable ${source_files} ${RESOURCES})
 target_include_directories(sample_navigable PUBLIC Qt5::QuickControls2)
 target_link_libraries(sample_navigable Qt5::Core Qt5::Gui Qt5::QuickControls2)
+
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+    add_custom_command(TARGET sample_navigable POST_BUILD
+        COMMAND ${WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE:sample_navigable> $<$<CONFIG:Debug>:--pdb>)
+    add_custom_command(TARGET sample_navigable POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QuickQanava> $<TARGET_FILE_DIR:sample_navigable>)
+endif()
+
 
 

--- a/samples/navigable/navigable.qml
+++ b/samples/navigable/navigable.qml
@@ -1,6 +1,7 @@
 import QtQuick          2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts  1.3
+import QtQuick.Shapes   1.0
 
 import QuickQanava 2.0 as Qan
 

--- a/samples/nodes/CMakeLists.txt
+++ b/samples/nodes/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Qt5Qml)
 find_package(Qt5QuickControls2 REQUIRED)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-qt5_wrap_cpp(source_files, header_files)
+#qt5_wrap_cpp(source_files, header_files)
 qt5_add_resources(RESOURCES nodes.qrc)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_QML_DEBUG>)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -32,6 +32,15 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(sample_nodes ${source_files} ${RESOURCES})
 target_include_directories(sample_nodes PUBLIC QuickQanava Qt5::QuickControls2)
 target_link_libraries(sample_nodes QuickQanava)
+
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+    add_custom_command(TARGET sample_nodes POST_BUILD
+        COMMAND ${WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE:sample_nodes> $<$<CONFIG:Debug>:--pdb>)
+    add_custom_command(TARGET sample_nodes POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QuickQanava> $<TARGET_FILE_DIR:sample_nodes>)
+endif()
+
 
 
 

--- a/samples/nodes/nodes.qml
+++ b/samples/nodes/nodes.qml
@@ -28,6 +28,7 @@ import QtQuick                   2.8
 import QtQuick.Controls          2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts           1.3
+import QtQuick.Shapes            1.0
 
 import QuickQanava 2.0 as Qan
 import "qrc:/QuickQanava" as Qan

--- a/samples/selection/CMakeLists.txt
+++ b/samples/selection/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Qt5Qml)
 find_package(Qt5QuickControls2 REQUIRED)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-qt5_wrap_cpp(source_files, header_files)
+#qt5_wrap_cpp(source_files, header_files)
 qt5_add_resources(RESOURCES selection.qrc)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_QML_DEBUG>)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -32,5 +32,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(sample_selection ${source_files} ${RESOURCES})
 target_include_directories(sample_selection PUBLIC QuickQanava Qt5::QuickControls2)
 target_link_libraries(sample_selection QuickQanava QuickContainers Qt5::Core Qt5::Gui Qt5::QuickControls2)
+
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+    add_custom_command(TARGET sample_selection POST_BUILD
+        COMMAND ${WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE:sample_selection> $<$<CONFIG:Debug>:--pdb>)
+    add_custom_command(TARGET sample_selection POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QuickQanava> $<TARGET_FILE_DIR:sample_selection>)
+endif()
+
 
 

--- a/samples/selection/selection.qml
+++ b/samples/selection/selection.qml
@@ -28,6 +28,7 @@ import QtQuick                   2.8
 import QtQuick.Controls          2.1
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts           1.3
+import QtQuick.Shapes            1.0
 import Qt.labs.platform          1.0    // ColorDialog
 
 import QuickQanava          2.0 as Qan

--- a/samples/topology/CMakeLists.txt
+++ b/samples/topology/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(Qt5Qml)
 find_package(Qt5QuickControls2 REQUIRED)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-qt5_wrap_cpp(source_files, header_files)
+#qt5_wrap_cpp(source_files, header_files)
 qt5_add_resources(RESOURCES topology.qrc)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_QML_DEBUG>)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -33,5 +33,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(sample_topology ${source_files} ${RESOURCES})
 target_include_directories(sample_topology PUBLIC QuickQanava Qt5::QuickControls2)
 target_link_libraries(sample_topology QuickQanava QuickContainers Qt5::Core Qt5::Gui Qt5::QuickControls2)
+
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+    add_custom_command(TARGET sample_topology POST_BUILD
+        COMMAND ${WINDEPLOYQT_EXECUTABLE} --qmldir ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_FILE:sample_topology> $<$<CONFIG:Debug>:--pdb>)
+    add_custom_command(TARGET sample_topology POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QuickQanava> $<TARGET_FILE_DIR:sample_topology>)
+endif()
+
 
 

--- a/samples/topology/main.qml
+++ b/samples/topology/main.qml
@@ -28,6 +28,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls.Material 2.1
+import QtQuick.Shapes            1.0
 
 import QuickQanava 2.0 as Qan
 import "qrc:/QuickQanava" as Qan

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,7 @@ find_package(Qt5Quick 5.10 REQUIRED)
 find_package(Qt5Qml 5.10 REQUIRED)
 find_package(Qt5QuickControls2 5.10 REQUIRED)
 
-qt5_wrap_cpp(qan_source_files, qan_header_files)
+#qt5_wrap_cpp(qan_source_files, qan_header_files)
 qt5_add_resources(RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/QuickQanava.qrc)
 
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_QML_DEBUG>)


### PR DESCRIPTION
This pull request fixes a few issues with the CMake build system on the Windows platform.

Setup:
- Windows 10 Pro Build 16299
- CMake 3.10.1
- Qt 5.10.1
- Visual Studio 2017 15.5.7

Notes:

1. It is largely considered bad practice to override the default library type when adding a library target using add_library, because the user may wish to override the default by providing -DBUILD_SHARED_LIBS=1 on the command line. You override the default (STATIC) on line 76 of src/CMakeLists.txt, however do not then export library symbols.

If the user has a version of CMake >= 3.5 then he may provide -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS on the command-line, which will fix the linker error, but this causes ALL symbols to be exported, which results in a needlessly bloated .lib file, and requires a pretty recent version of CMake, however the minimum required version in CMakeLists.txt is 3.5.0, so perhaps this is acceptable.

tl;dr Do not override the default library type unless you minimally provide appropriate dllimport / dllexport storage-class attributes.


2. You should do **one** of either setting CMAKE_AUTOMOC=ON **OR** calling qt5_wrap_cpp, but not both. Note that the function invocation in the various CMakeLists.txt files incorrectly uses a comma to separate parameters, which is invalid CMake syntax, and causes a configuration error on Windows. I chose to remove the call to qt5_wrap_cpp, since the function invocation was wrong anyway.


4. Consider adding post build actions to deploy the necessary DLL dependencies to output folders. This is necessary on Windows to enable use of the debugger. Related to this, the windeployqt command-line utility will handle all dependencies, however for QML dependencies only a single qmldir directory may be specified, so it is useful to include all dependencies in the main .qml file. I'm sure there are other ways of improving this, but for simplicity I manually added the QtQuick.Shapes import to the root / main qml file for each sample, enabling windeployqt to find all dependencies necessary to run the binary.


After fixing these issues I was able to successfully run the samples on Windows, with the caveat that there appears to be a problem with qan::Connector::setEdgeComponent which prints the following non-descriptive error message "Error while creating edge: ()", which I have not yet tracked down to the root cause. Is this working on other platforms?