### PR TITLE
Fix Qt bug exposing C++ enum class to QML

### DIFF
--- a/samples/dataflow/qanDataFlow.h
+++ b/samples/dataflow/qanDataFlow.h
@@ -190,6 +190,8 @@ public:
 
 QML_DECLARE_TYPE( qan::FlowNode )
 QML_DECLARE_TYPE( qan::FlowGraph )
+Q_DECLARE_METATYPE( qan::FlowNode::Type )
+Q_DECLARE_METATYPE( qan::OperationNode::Operation )
 
 #endif // qanDataFlow_h
 

--- a/src/qanNodeItem.h
+++ b/src/qanNodeItem.h
@@ -463,6 +463,7 @@ private:
 } // ::qan
 
 QML_DECLARE_TYPE(qan::NodeItem)
+Q_DECLARE_METATYPE(qan::NodeItem::Connectable)
 Q_DECLARE_METATYPE(qan::NodeItem::Dock)
 
 #endif // qanNodeItem_h

--- a/src/qanPortItem.h
+++ b/src/qanPortItem.h
@@ -169,5 +169,7 @@ protected:
 } // ::qan
 
 QML_DECLARE_TYPE( qan::PortItem )
+Q_DECLARE_METATYPE( qan::PortItem::Type )
+Q_DECLARE_METATYPE( qan::PortItem::Multiplicity )
 
 #endif // qanPortItem_h

--- a/src/qanStyle.h
+++ b/src/qanStyle.h
@@ -408,6 +408,9 @@ signals:
 QML_DECLARE_TYPE( qan::Style )
 QML_DECLARE_TYPE( qan::NodeStyle )
 QML_DECLARE_TYPE( qan::EdgeStyle )
+Q_DECLARE_METATYPE( qan::NodeStyle::FillType )
+Q_DECLARE_METATYPE( qan::NodeStyle::EffectType )
+Q_DECLARE_METATYPE( qan::EdgeStyle::LineType )
 
 #endif // qanStyle_h
 


### PR DESCRIPTION
As reported in https://github.com/cneben/QuickQanava/issues/44