### PR TITLE
Fix plugin import when used in a cmake subdirectory

### DIFF
--- a/src/QuickQanava_plugin.qrc
+++ b/src/QuickQanava_plugin.qrc
@@ -26,5 +26,6 @@
         <file>VisualConnector.qml</file>
         <file>LabelEditor.qml</file>
         <file alias="qmldir">qmldir_plugin</file>
+        <file>RectShadowEffect.qml</file>
     </qresource>
 </RCC>

--- a/src/qanPlugin.cpp
+++ b/src/qanPlugin.cpp
@@ -71,6 +71,7 @@ static const struct {
     { "Group", 2, 0 },
     { "RectNodeTemplate", 2, 0 },
     { "RectSolidBackground",  2, 0 },
+    { "RectShadowEffect", 2, 0 },
     { "RectGroupTemplate",  2, 0 },
     { "CanvasNodeTemplate",  2, 0 },
     { "VisualConnector",  2, 0 },
@@ -138,6 +139,6 @@ QString QuickQanavaPlugin::fileLocation() const
 bool QuickQanavaPlugin::isLoadedFromResource() const
 {
     // If one file is missing, it will load all the files from the resource
-    QFile file(baseUrl().toLocalFile() + qmldir[0].type + ".qml");
+    QFile file(baseUrl().toLocalFile() + "/" + qmldir[0].type + ".qml");
     return !file.exists();
 }

--- a/src/qmldir_plugin
+++ b/src/qmldir_plugin
@@ -11,6 +11,7 @@ GraphView           2.0 GraphView.qml
 Group               2.0 Group.qml
 RectNodeTemplate    2.0 RectNodeTemplate.qml
 RectSolidBackground 2.0 RectSolidBackground.qml
+RectShadowEffect    2.0 RectShadowEffect.qml
 RectGroupTemplate   2.0 RectGroupTemplate.qml
 CanvasNodeTemplate  2.0 CanvasNodeTemplate.qml
 VisualConnector     2.0 VisualConnector.qml


### PR DESCRIPTION
Add RectShadowEffect to resources as it was missing. Fix up the plugin path missing a / before the file name it was checking against