### PR TITLE
Add Qbs files for building library (statically).

### DIFF
--- a/GTpo/gtpo.qbs
+++ b/GTpo/gtpo.qbs
@@ -1,0 +1,75 @@
+import qbs
+
+Project {
+    name: "GTpo";
+
+    Product {
+        name: "gtpo";
+        targetName: "GTpo";
+
+        readonly property stringList qtModules : ["core"];
+
+        Export {
+            cpp.includePaths: "src/";
+
+            Depends { name: "cpp"; }
+            Depends {
+                name: "Qt";
+                submodules: product.qtModules;
+            }
+        }
+        Depends { name: "cpp"; }
+        cpp.cxxLanguageVersion: "c++14"
+        cpp.warningLevel: "all"
+        Depends {
+            name: "Qt";
+            submodules: product.qtModules;
+        }
+        Group {
+            name: "C++ headers";
+            prefix: "src/gtpo/"
+            files: [
+                "utils.h",
+                "config.h",
+                "edge.h",
+                "edge.hpp",
+                "node.h",
+                "node.hpp",
+                "group.h",
+                "group.hpp",
+                "graph.h",
+                "graph.hpp",
+                "graph_property.h",
+                "algorithm.h",
+                "algorithm.hpp",
+                "functional.h",
+                "generator.h",
+                "generator.hpp",
+                "behaviour.h",
+                "behaviourable.h",
+                "behaviourable.hpp",
+                "graph_behaviour.h",
+                "graph_behaviour.hpp",
+                "node_behaviour.h",
+                "node_behaviour.hpp",
+                "group_behaviour.h",
+                "group_behaviour.hpp",
+                "adjacent_behaviour.h",
+                "adjacent_behaviour.hpp",
+                "container_adapter.h",
+                "GTpo.h"
+            ]
+        }
+        Group {
+            name: "Include library";
+            prefix: "src/gtpo/"
+            files: [
+                "GTpo"
+            ]
+        }
+        Group {
+            qbs.install: (product.type === "dynamiclibrary");
+            fileTagsFilter: product.type;
+        }
+    }
+}

--- a/QuickContainers/quickcontainers.qbs
+++ b/QuickContainers/quickcontainers.qbs
@@ -1,0 +1,41 @@
+import qbs
+
+StaticLibrary {
+    name: "quickcontainers"
+    readonly property stringList qtModules : ["core", "widgets", "gui", "qml"]
+
+    Depends { name: "cpp"; }
+    cpp.cxxLanguageVersion: "c++14"
+    cpp.warningLevel: "all"
+    Depends {
+        name: "Qt";
+        submodules: product.qtModules
+    }
+    Export {
+        cpp.includePaths: ["include/"]
+
+        Depends { name: "cpp"; }
+        Depends {
+            name: "Qt";
+            submodules: product.qtModules;
+        }
+    }
+    Group {
+        name: "C++ headers";
+        prefix: "include/"
+        files: [
+            "qcmContainerModel.h",
+            "qcmAbstractContainer.h",
+            "qcmAdapter.h",
+            "qcmContainer.h",
+            "QuickContainers.h"
+        ]
+    }
+    Group {
+        name: "Include library";
+        prefix: "include/"
+        files: [
+            "QuickContainers"
+        ]
+    }
+}

--- a/quickqanava.qbs
+++ b/quickqanava.qbs
@@ -1,0 +1,108 @@
+import qbs
+
+Project {
+    name: "QuickQanava";
+    references: [
+        "QuickContainers/quickcontainers.qbs",
+        "GTpo/gtpo.qbs"
+    ];
+
+    StaticLibrary {
+        name: "quickqanava";
+        cpp.cxxLanguageVersion: "c++14"
+        cpp.defines: ["QUICKQANAVA_STATIC"]
+
+        readonly property stringList qtModules : ["core", "widgets", "gui", "qml", "quick"];
+
+        Export {
+            cpp.includePaths: [product.sourceDirectory];
+
+            Depends { name: "cpp"; }
+            Depends { name: "gtpo" }
+            Depends { name: "quickcontainers" }
+            Depends {
+                name: "Qt";
+                submodules: product.qtModules;
+            }
+        }
+        Depends { name: "cpp"; }
+        cpp.warningLevel: "all"
+        Depends {
+            name: "Qt";
+            submodules: product.qtModules;
+        }
+        Depends { name: "gtpo" }
+        Depends { name: "quickcontainers" }
+
+        Group {
+            name: "C++ sources";
+            prefix: "src/"
+            files: [
+                "qanGraphView.cpp",
+                "qanUtils.cpp",
+                "qanEdge.cpp",
+                "qanEdgeItem.cpp",
+                "qanNode.cpp",
+                "qanNodeItem.cpp",
+                "qanPortItem.cpp",
+                "qanSelectable.cpp",
+                "qanDraggable.cpp",
+                "qanConnector.cpp",
+                "qanBehaviour.cpp",
+                "qanGraph.cpp",
+                "qanGroup.cpp",
+                "qanGroupItem.cpp",
+                "qanStyle.cpp",
+                "qanStyleManager.cpp",
+                "qanNavigable.cpp",
+                "qanNavigablePreview.cpp",
+                "qanGrid.cpp",
+                "qanBottomRightResizer.cpp"
+            ]
+        }
+        Group {
+            name: "C++ headers";
+            prefix: "src/"
+            files: [
+                "QuickQanava.h",
+                "qanUtils.h",
+                "qanGraphConfig.h",
+                "qanGraphView.h",
+                "qanEdge.h",
+                "qanEdgeItem.h",
+                "qanNode.h",
+                "qanNodeItem.h",
+                "qanPortItem.h",
+                "qanSelectable.h",
+                "qanDraggable.h",
+                "qanAbstractDraggableCtrl.h",
+                "qanDraggableCtrl.h",
+                "qanDraggableCtrl.hpp",
+                "qanConnector.h",
+                "qanBehaviour.h",
+                "qanGroup.h",
+                "qanGroupItem.h",
+                "qanGraph.h",
+                "qanGraph.hpp",
+                "qanStyle.h",
+                "qanStyleManager.h",
+                "qanNavigable.h",
+                "qanNavigablePreview.h",
+                "qanGrid.h",
+                "qanContainerAdapter.h",
+                "qanBottomRightResizer.h"
+            ]
+        }
+        Group {
+            name: "Qt resources bundle";
+            prefix: "src/"
+            files: [
+                "QuickQanava_static.qrc"
+            ]
+        }
+        Group {
+            qbs.install: (product.type === "dynamiclibrary");
+            fileTagsFilter: product.type;
+        }
+    }
+}


### PR DESCRIPTION
Use the latest (promoted) build system Qbs for building the library.

Use:

- Under your application Project {} use quickqanava.qbs as reference file:
references: ["QuickQanava/quickqanava.qbs"]
- Depend in your application, e.g. QtApplication on quickqanava:
Depends { name: "quickqanava" }

Making a dynamic library should/can be added later on.