### PR TITLE
restore qcm::Containers observing of destroyed event

### DIFF
--- a/QuickContainers/include/qcmContainer.h
+++ b/QuickContainers/include/qcmContainer.h
@@ -288,12 +288,12 @@ private:
     inline auto appendImpl( const T&, ItemDispatcherBase::non_ptr_type ) noexcept  -> void {}
     inline auto appendImpl( const T& item, ItemDispatcherBase::ptr_qobject_type ) noexcept  -> void {
         if ( item != nullptr ) {
-            /*connect( item, &QObject::destroyed,
-                     [this](auto o) {
-                        if (this->contains(qobject_cast<T>(o))) // Do not remove if item is no longer contained
-                            this->removeAll(qobject_cast<T>(o));
+            QPointer<Container<C, T>> weakThis = this;
+            connect( item, &QObject::destroyed,
+                     [weakThis](auto o) {
+                        if (weakThis && weakThis->contains(qobject_cast<T>(o)))
+                            weakThis->removeAll(qobject_cast<T>(o));
                         } );
-                        */
             if ( _modelImpl  )
                 _modelImpl->_qObjectItemMap.insert( { item, item } );
         }


### PR DESCRIPTION
The following comment in qanPortItem.h

``` 
    /* Note: qcm::ContainerModel automatically monitor contained
     * object for destruction, just delete an item with deleteLater() to
     * remove it.
     */
    using EdgeItems =   qcm::Container<QVector, qan::EdgeItem*>;
```

does not seem to hold true as it looks like that functionality in qcmContainer.h has been commented out  in https://github.com/cneben/QuickQanava/commit/2b95f2d54a43be8efe73bfeaef2aaf1657cd13db

We've restored that functionality (as we has a problem with dangling pointers staying in the list) and I've also gone ahead to use QPointers instead of raw this, to not crash if the whole container has been destroyed prior to any of its elements, possibly the reason why it was disabled.

Sorry if I'm a bit unclear, now back to work! 👏 