### PR TITLE
Ensure selected groups are always only in selectedGroups()

### DIFF
--- a/src/qanGraph.cpp
+++ b/src/qanGraph.cpp
@@ -1183,10 +1183,21 @@ bool    Graph::selectNode(qan::Node* node)
     return (node != nullptr ? selectNode(*node) : false);
 }
 
-void    Graph::setNodeSelected(qan::Node& node, bool selected) { impl::setPrimitiveSelected<qan::Node>(node, selected, *this); }
+void    Graph::setNodeSelected(qan::Node& node, bool selected)
+{
+    if (node.isGroup())
+        impl::setPrimitiveSelected<qan::Group>(dynamic_cast<qan::Group&>(node), selected, *this);
+    else
+        impl::setPrimitiveSelected<qan::Node>(node, selected, *this);
+}
+
 void    Graph::setNodeSelected(qan::Node* node, bool selected)
 {
-    if (node != nullptr)
+    if (node == nullptr)
+        return;
+    if (node->isGroup())
+        impl::setPrimitiveSelected<qan::Group>(dynamic_cast<qan::Group&>(*node), selected, *this);
+    else
         impl::setPrimitiveSelected<qan::Node>(*node, selected, *this);
 }
 


### PR DESCRIPTION
Groups that are selected with rectangle selection are currently added to selectedNodes() but not to selectedGroups() and groups that are selected with Ctrl+Click are added to selectedGroups() but not to selectedNodes().

The proposed fix ensures that selected groups are always only returned in selectedGroups() and only nodes that are not groups are returned in selectedNodes().