### PR TITLE
Drop FINAL feature on graph property

### DIFF
--- a/src/qanNodeItem.h
+++ b/src/qanNodeItem.h
@@ -115,7 +115,7 @@ private:
 
 public:
     //! Secure shortcut to getNode().getGraph().
-    Q_PROPERTY(qan::Graph* graph READ getGraph CONSTANT FINAL)
+    Q_PROPERTY(qan::Graph* graph READ getGraph CONSTANT)
     //! \copydoc graph
     auto    setGraph(qan::Graph* graph) noexcept -> void;
 protected:


### PR DESCRIPTION
graph property is overridden in qan::Connector but marked as FINAL in qan::NodeItem. Qt 6.2.0 will not allow this anymore and use the graph property from qan::NodeItem while previous Qt versions would use the graph property from qan::Connector.