### PR TITLE
Fix compilation with Qt < 5.14

### DIFF
--- a/src/qanNavigable.cpp
+++ b/src/qanNavigable.cpp
@@ -440,7 +440,11 @@ void    Navigable::wheelEvent(QWheelEvent* event)
 {
     if (getNavigable()) {
         qreal zoomFactor = (event->angleDelta().y() > 0. ? _zoomIncrement : -_zoomIncrement);
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
         zoomOn(event->position(), getZoom() + zoomFactor);
+#else // QWheelEvent::position was added in Qt 5.14; pos was deprecated in 5.15.
+        zoomOn(event->pos(), getZoom() + zoomFactor);
+#endif
     }
     updateGrid();
     // Note 20160117: NavigableArea is opaque for wheel events, do not call QQuickItem::wheelEvent(event);


### PR DESCRIPTION
Fix compilation with Qt < 5.14; QWheelEvent::position was added in 5.14 ("This function was introduced in Qt 5.14.", https://doc.qt.io/qt-5/qwheelevent.html#position)

\QuickQanava\master\src\qanNavigable.cpp(443,23): error C2039: 'position': is not a member of 'QWheelEvent'
\Qt\5.13.0\msvc2015_64\include\QtGui/qevent.h(173): message : see declaration of 'QWheelEvent'
Done building project "QuickQanava.vcxproj" -- FAILED.