### PR TITLE
Made a number of destructors virtual where needed

### DIFF
--- a/src/gtpo/graph.h
+++ b/src/gtpo/graph.h
@@ -93,7 +93,7 @@ public:
         graph_base_t{parent},
         observable_base_t{} { }
 
-    ~graph();
+    virtual ~graph();
 
     graph(const graph&) = delete;
     graph& operator=(const graph&) = delete;

--- a/src/gtpo/observable.h
+++ b/src/gtpo/observable.h
@@ -49,7 +49,7 @@ namespace gtpo { // ::gtpo
 class abstract_observable {
 public:
     abstract_observable() {}
-    ~abstract_observable() = default;
+    virtual ~abstract_observable() = default;
 
     abstract_observable(const abstract_observable&) = default;
     abstract_observable& operator=( const abstract_observable&) = default;
@@ -68,7 +68,7 @@ class observable : public abstract_observable
     //@{
 public:
     observable() : abstract_observable() { }
-    ~observable() noexcept {
+    virtual ~observable() noexcept {
         _observers.clear();
     }
     observable(const observable<observer_t>&) = default;
@@ -199,7 +199,7 @@ public:
     using graph_observer_t = gtpo::graph_observer<graph_t, node_t, edge_t, group_t>;
     using super_t = observable<gtpo::graph_observer<graph_t, node_t, edge_t, group_t> >;
     observable_graph() : super_t{} { }
-    ~observable_graph() noexcept = default;
+    virtual ~observable_graph() noexcept = default;
     observable_graph(const observable_graph<graph_t, node_t, edge_t, group_t>&) = delete;
     observable_graph& operator=(const observable_graph<graph_t, node_t, edge_t, group_t>&) = delete;
     //@}

--- a/src/gtpo/observer.h
+++ b/src/gtpo/observer.h
@@ -154,7 +154,7 @@ public:
 
     using this_t = gtpo::graph_observer<graph_t, node_t, edge_t, group_t>;
     graph_observer() noexcept : gtpo::observer<graph_t>{} {}
-    ~graph_observer() noexcept = default;
+    virtual ~graph_observer() noexcept = default;
     graph_observer(const this_t&) = delete;
     graph_observer& operator=(const this_t&) = delete;
 


### PR DESCRIPTION
When building QuickQanava with clang 15.x and pedantic build settings, we get a number of build errors that destructors are not virtual when dynamic polymorphism would require them to be so. This PR fixes the build by making the destructors virtual, where needed.

Please kindly review!