### PR TITLE
Fix a crash on destruction of qan::Navigatable

### DIFF
--- a/src/qanNavigable.cpp
+++ b/src/qanNavigable.cpp
@@ -59,6 +59,14 @@ Navigable::Navigable(QQuickItem* parent) :
     setGrid(_defaultGrid.get());
     setAcceptTouchEvents(true);
 }
+
+Navigable::~Navigable()
+{
+    disconnect(_containerItem, nullptr, this, nullptr);
+    if (_grid) {
+        disconnect(_grid, nullptr, this, nullptr);
+    }
+}
 //-----------------------------------------------------------------------------
 
 /* Navigation Management *///--------------------------------------------------
@@ -495,8 +503,8 @@ void    Navigable::setGrid(qan::Grid* grid) noexcept
             _grid->setZ(-1.0);
             _grid->setAntialiasing(false);
             _grid->setScale(1.0);
-            connect(grid,   &QQuickItem::visibleChanged, // Force updateGrid when visibility is changed to eventually
-                    this,   &Navigable::updateGrid);    // take into account any grid property change while grid was hidden.
+            connect(_grid,  &QQuickItem::visibleChanged, // Force updateGrid when visibility is changed to eventually
+                    this,   &Navigable::updateGrid);     // take into account any grid property change while grid was hidden.
         }
         if (!_grid)
             _grid = _defaultGrid.get(); // Do not connect default grid, it is an "empty grid"

--- a/src/qanNavigable.h
+++ b/src/qanNavigable.h
@@ -96,7 +96,7 @@ class Navigable : public QQuickItem
 Q_OBJECT
 public:
     explicit Navigable(QQuickItem* parent = nullptr);
-    virtual ~Navigable() override = default;
+    virtual ~Navigable() override;
     Navigable(const Navigable&) = delete;
     //@}
     //-------------------------------------------------------------------------


### PR DESCRIPTION
When the destructor is called, it will change the child, which will trigger a signal to the parent. This can lead to a crash because the parent is in process of destruction.