### PR TITLE
src/gtpo/graph.h: Fixed a minor compile issue wih Qt 6.7.0

### DIFF
--- a/src/gtpo/graph.h
+++ b/src/gtpo/graph.h
@@ -157,6 +157,9 @@ public:
      */
     auto    is_root_node(const node_t* node) const -> bool;
 
+    //! Expose the base class method of the same name:
+    using   graph_base_t::contains;
+
     //! Use fast search container to find if a given \c node is part of this graph.
     auto    contains(const node_t* node) const -> bool;
 


### PR DESCRIPTION
This is a trivial fix for building against Qt 6.7.0: Expose the base class method `contains` that is otherwise hidden, due to overload resolution rules.