### PR TITLE
Adding ability to disable editing node label on double click

### DIFF
--- a/src/RectNodeTemplate.qml
+++ b/src/RectNodeTemplate.qml
@@ -46,8 +46,9 @@ Item {
     id: template
 
     // PUBLIC /////////////////////////////////////////////////////////////////
-    property var            nodeItem : undefined
-    default property alias  children : contentLayout.children
+    property var                         nodeItem : undefined
+    default property alias               children : contentLayout.children
+    property alias enableLabelEditorOnDoubleClick : doubleClickLabelEditorConnections.enabled
 
     // PRIVATE ////////////////////////////////////////////////////////////////
     onNodeItemChanged: {
@@ -119,6 +120,7 @@ Item {
         }
     }
     Connections {
+        id: doubleClickLabelEditorConnections
         target: nodeItem
         function onNodeDoubleClicked() { labelEditor.visible = true }
     }


### PR DESCRIPTION
Hi, it would be nice to add support for disabling node label editing on double click.

This implementation adds the `enableLabelEditorOnDoubleClick` flag to `RectNodeTemplate`, which allows to override the default behaviour in `Node` like this:
```qml
nodeDelegate: Qan.NodeItem {
    id: nodeItem
    width: 110
    height: 50

    Qan.RectNodeTemplate {
        anchors.fill: parent
        enableLabelEditorOnDoubleClick: false
        nodeItem : parent
    }
}

```


This is how we implemented it on our side, feel free to suggest another approach.
