### PR TITLE
Add Qt 6.8 support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,7 +141,6 @@ set(qan_qml_files
 
 # Configure Qt
 set(CMAKE_AUTOMOC ON)
-qt_wrap_cpp(qan_source_files, qan_header_files)   # Creates .moc files from sources
 set(CMAKE_AUTORCC ON)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:QT_QML_DEBUG>)
 
@@ -202,5 +201,3 @@ target_link_libraries(QuickQanava PUBLIC Qt6::Core
                                          Qt6::Qml
                                          Qt6::Quick
                                          Qt6::QuickControls2)
-
-

--- a/src/qanBottomResizer.cpp
+++ b/src/qanBottomResizer.cpp
@@ -216,7 +216,7 @@ void    BottomResizer::mousePressEvent(QMouseEvent* event)
     if (!isVisible())
         return;
     if (_target) {
-        _dragInitialPos = event->windowPos();
+        _dragInitialPos = event->scenePosition();
         _targetInitialSize = {_target->width(), _target->height()};
         emit resizeStart(_target ? QSizeF{_target->width(), _target->height()} :  // Use of target ok.
                                   QSizeF{});

--- a/src/qanEdgeDraggableCtrl.cpp
+++ b/src/qanEdgeDraggableCtrl.cpp
@@ -86,7 +86,7 @@ bool    EdgeDraggableCtrl::handleMouseMoveEvent(QMouseEvent* event)
     const auto rootItem = graph->getContainerItem();
     if (rootItem != nullptr &&      // Root item exist, left button is pressed and the target item
         event->buttons().testFlag(Qt::LeftButton)) {    // is draggable and not collapsed
-        const auto sceneDragPos = rootItem->mapFromGlobal(event->globalPos());
+        const auto sceneDragPos = rootItem->mapFromGlobal(event->globalPosition());
         if (!_targetItem->getDragged()) {
             beginDragMove(sceneDragPos, _targetItem->getSelected());
             return true;

--- a/src/qanEdgeItem.cpp
+++ b/src/qanEdgeItem.cpp
@@ -1116,8 +1116,8 @@ void    EdgeItem::mouseDoubleClickEvent(QMouseEvent* event)
 {
     if ((getEdge() != nullptr && !getEdge()->getLocked()) &&
         event->button() == Qt::LeftButton &&
-        contains(event->localPos())) {
-        emit edgeDoubleClicked(this, event->localPos());
+        contains(event->position())) {
+        emit edgeDoubleClicked(this, event->position());
         event->accept();
     }
     else
@@ -1130,7 +1130,7 @@ void    EdgeItem::mousePressEvent(QMouseEvent* event)
     // Note 20211030: Do not take getLocked() into account,
     // otherwise onEdgeDoubleClicked() is no longer fired (and edge
     // can't be unlocked with a visual editor !
-    if (contains(event->localPos())) {
+    if (contains(event->position())) {
         // Selection management
         if ((event->button() == Qt::LeftButton ||
              event->button() == Qt::RightButton) &&
@@ -1142,11 +1142,11 @@ void    EdgeItem::mousePressEvent(QMouseEvent* event)
         }
 
         if (event->button() == Qt::LeftButton) {
-            emit edgeClicked(this, event->localPos());
+            emit edgeClicked(this, event->position());
             event->accept();
         }
         else if (event->button() == Qt::RightButton) {
-            emit edgeRightClicked(this, event->localPos());
+            emit edgeRightClicked(this, event->position());
             event->accept();
         }
     } else
@@ -1361,7 +1361,7 @@ void    EdgeItem::dragEnterEvent(QDragEnterEvent* event)
 void	EdgeItem::dragMoveEvent(QDragMoveEvent* event)
 {
     if (getAcceptDrops()) {
-        qreal d = distanceFromLine(event->posF( ), QLineF{_p1, _p2});
+        qreal d = distanceFromLine(event->position(), QLineF{_p1, _p2});
         if (d > 0. && d < 5.)
             event->accept();
         else event->ignore();

--- a/src/qanGraph.cpp
+++ b/src/qanGraph.cpp
@@ -243,7 +243,7 @@ qan::Group* Graph::groupAt(const QPointF& p, const QSizeF& s, const QQuickItem* 
     // 1.
     std::vector<qan::Group*> groups;
     groups.reserve(static_cast<unsigned int>(get_groups().size()));
-    for (const auto group : qAsConst(get_groups().getContainer())) {
+    for (const auto group : std::as_const(get_groups().getContainer())) {
         if (group != nullptr)
             groups.push_back(group);
     }
@@ -265,7 +265,7 @@ qan::Group* Graph::groupAt(const QPointF& p, const QSizeF& s, const QQuickItem* 
     // 3.
     if (getContainerItem() == nullptr)
             return nullptr;
-    for (const auto group : qAsConst(groups)) {
+    for (const auto group : std::as_const(groups)) {
         if (group &&
             group->getItem() != nullptr &&
             group->getItem() != except) {
@@ -1396,21 +1396,21 @@ void    Graph::selectAll()
 void    Graph::removeSelection()
 {
     const auto& selectedNodes = getSelectedNodes();
-    for (const auto& node: qAsConst(selectedNodes))
+    for (const auto& node: std::as_const(selectedNodes))
         if (node &&
             !node->getIsProtected() &&
             !node->getLocked())
             removeNode(node);
 
     const auto& selectedGroups = getSelectedGroups();
-    for (const auto& group: qAsConst(selectedGroups))
+    for (const auto& group: std::as_const(selectedGroups))
         if (group &&
             !group->getIsProtected() &&
             !group->getLocked())
             removeGroup(group);
 
     const auto& selectedEdges = getSelectedEdges();
-    for (const auto& edge: qAsConst(selectedEdges))
+    for (const auto& edge: std::as_const(selectedEdges))
         if (edge &&
             !edge->getIsProtected() &&
             !edge->getLocked())
@@ -1449,7 +1449,7 @@ void    Graph::clearSelection()
     std::copy(_selectedEdges.cbegin(),
               _selectedEdges.cend(),
               std::back_inserter(selectedEdgesCopy));
-    for (auto& edge : qAsConst(selectedEdgesCopy))
+    for (auto& edge : std::as_const(selectedEdgesCopy))
         if (edge != nullptr &&
             edge->getItem() != nullptr)
             edge->getItem()->setSelected(false);
@@ -2262,7 +2262,7 @@ bool    Graph::isAncestor(const qan::Node& node, const qan::Node& candidate) con
 auto    Graph::collectGroupsNodes(const QVector<const qan::Group*>& groups) const noexcept -> std::unordered_set<const qan::Node*>
 {
     std::unordered_set<const qan::Node*> r;
-    for (const auto group: qAsConst(groups))  // Collect all group nodes and their sub groups nodes
+    for (const auto group: std::as_const(groups))  // Collect all group nodes and their sub groups nodes
         if (group != nullptr)           // recursively
             collectGroupNodes_rec(group, r);
     return r;

--- a/src/qanGroup.cpp
+++ b/src/qanGroup.cpp
@@ -58,7 +58,7 @@ std::unordered_set<qan::Edge*>  Group::collectAdjacentEdges() const
 {
     std::unordered_set<qan::Edge*> edges = qan::Node::collectAdjacentEdges();
     if (is_group()) {
-        for (const auto groupNode: qAsConst(group_nodes())) {
+        for (const auto groupNode: std::as_const(group_nodes())) {
             if (groupNode != nullptr) {
                 const auto qanGroupNode = qobject_cast<qan::Group*>(groupNode);
                 if (qanGroupNode != nullptr) {

--- a/src/qanGroupItem.cpp
+++ b/src/qanGroupItem.cpp
@@ -217,7 +217,7 @@ void    GroupItem::mouseDoubleClickEvent(QMouseEvent* event)
     if (event->button() == Qt::LeftButton &&
         (getNode() != nullptr &&
          !getNode()->getLocked()))
-        emit groupDoubleClicked(this, event->localPos());
+        emit groupDoubleClicked(this, event->position());
 }
 
 void    GroupItem::mousePressEvent(QMouseEvent* event)
@@ -235,9 +235,9 @@ void    GroupItem::mousePressEvent(QMouseEvent* event)
     }
 
     if (event->button() == Qt::LeftButton)
-        emit groupClicked(this, event->localPos());
+        emit groupClicked(this, event->position());
     else if (event->button() == Qt::RightButton)
-        emit groupRightClicked(this, event->localPos());
+        emit groupRightClicked(this, event->position());
 }
 //-----------------------------------------------------------------------------
 

--- a/src/qanNode.cpp
+++ b/src/qanNode.cpp
@@ -140,11 +140,11 @@ QAbstractItemModel* Node::qmlGetOutEdges() const
 std::unordered_set<qan::Edge*>  Node::collectAdjacentEdges() const
 {
     std::unordered_set<qan::Edge*> edges;
-    for (const auto in_edge: qAsConst(get_in_edges())) {
+    for (const auto in_edge: std::as_const(get_in_edges())) {
         if (in_edge != nullptr)
             edges.insert(in_edge);
     }
-    for (const auto out_edge: qAsConst(get_out_edges())) {
+    for (const auto out_edge: std::as_const(get_out_edges())) {
         if (out_edge != nullptr)
             edges.insert(out_edge);
     }

--- a/src/qanNodeItem.cpp
+++ b/src/qanNodeItem.cpp
@@ -444,7 +444,7 @@ bool    NodeItem::isInsideBoundingShape(QPointF p)
 /* Port/Dock Management *///---------------------------------------------------
 qan::PortItem*  NodeItem::findPort(const QString& portId) const noexcept
 {
-    for (const auto port : qAsConst(_ports)){   // Note: std::as_const is officially c++17
+    for (const auto port : std::as_const(_ports)){   // Note: std::as_const is officially c++17
         const auto portItem = qobject_cast<qan::PortItem*>(port);
         if (portItem != nullptr &&
             portItem->getId() == portId) {
@@ -457,7 +457,7 @@ qan::PortItem*  NodeItem::findPort(const QString& portId) const noexcept
 
 void    NodeItem::updatePortsEdges()
 {
-    for (const auto port : qAsConst(_ports)){   // Note: std::as_const is officially c++17
+    for (const auto port : std::as_const(_ports)){   // Note: std::as_const is officially c++17
         const auto portItem = qobject_cast<qan::PortItem*>(port);
         if (portItem != nullptr)
             portItem->updateEdges();

--- a/src/qanNodeItem.cpp
+++ b/src/qanNodeItem.cpp
@@ -309,7 +309,7 @@ void    NodeItem::mouseDoubleClickEvent(QMouseEvent* event)
     if (event->button() == Qt::LeftButton &&
         (getNode() != nullptr &&
          !getNode()->getLocked()))
-        emit nodeDoubleClicked(this, event->localPos());
+        emit nodeDoubleClicked(this, event->position());
 }
 
 void    NodeItem::mouseMoveEvent(QMouseEvent* event)
@@ -331,7 +331,7 @@ void    NodeItem::mouseMoveEvent(QMouseEvent* event)
 void    NodeItem::mousePressEvent(QMouseEvent* event)
 {
     bool accepted = !getCollapsed() &&            // Fast exit
-                    isInsideBoundingShape(event->localPos());
+                    isInsideBoundingShape(event->position());
     if (accepted) {
         forceActiveFocus();
 
@@ -348,9 +348,9 @@ void    NodeItem::mousePressEvent(QMouseEvent* event)
 
         // QML notifications
         if (event->button() == Qt::LeftButton)
-            emit nodeClicked(this, event->localPos());
+            emit nodeClicked(this, event->position());
         else if (event->button() == Qt::RightButton)
-            emit nodeRightClicked(this, event->localPos());
+            emit nodeRightClicked(this, event->position());
         event->accept();
     } else
         event->ignore();

--- a/src/qanTableGroupItem.cpp
+++ b/src/qanTableGroupItem.cpp
@@ -608,7 +608,7 @@ void    TableGroupItem::mouseDoubleClickEvent(QMouseEvent* event)
     if (event->button() == Qt::LeftButton &&
         (getNode() != nullptr &&
          !getNode()->getLocked()))
-        emit groupDoubleClicked(this, event->localPos());
+        emit groupDoubleClicked(this, event->position());
 }
 
 void    TableGroupItem::mousePressEvent(QMouseEvent* event)
@@ -625,9 +625,9 @@ void    TableGroupItem::mousePressEvent(QMouseEvent* event)
     }
 
     if (event->button() == Qt::LeftButton)
-        emit groupClicked(this, event->localPos());
+        emit groupClicked(this, event->position());
     else if (event->button() == Qt::RightButton)
-        emit groupRightClicked(this, event->localPos());
+        emit groupRightClicked(this, event->position());
 }
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
There are a number of deprecated methods in Qt 6.8. I have replaced them with their updated counterparts. Also, the manual wrapping for `moc` in cmake seems not supported but also not needed any more.
