### PR TITLE
Fix segfault after removing edges from PortItem

### DIFF
--- a/src/qanPortItem.cpp
+++ b/src/qanPortItem.cpp
@@ -112,8 +112,9 @@ void    PortItem::addOutEdgeItem(qan::EdgeItem& outEdgeItem) noexcept
 void    PortItem::onEdgeItemDestroyed(QObject* obj)
 {
     // Connection to destroyed signal in addInEdgeItem() and addOutEdgeItem()
-    // The object has already been partially destroyed so casting to the derived EdgeItem class is unsafe.
-    // We do this only to remove the EdgeItem from our internal lists.
+    // The object has already been partially destroyed from graph::remove_edge() so casting to the derived
+    // EdgeItem class is "unsafe" (ie return nullptr since object has been destroyed) using a qobject_cast<>
+    // Use a static_cast to force removing EdgeItem from our internal lists.
     const auto edgeItem_unsafe = static_cast<qan::EdgeItem*>(obj);
     if (edgeItem_unsafe != nullptr)
     {

--- a/src/qanPortItem.cpp
+++ b/src/qanPortItem.cpp
@@ -112,10 +112,13 @@ void    PortItem::addOutEdgeItem(qan::EdgeItem& outEdgeItem) noexcept
 void    PortItem::onEdgeItemDestroyed(QObject* obj)
 {
     // Connection to destroyed signal in addInEdgeItem() and addOutEdgeItem()
-    const auto edgeItem = qobject_cast<qan::EdgeItem*>(obj);
-    if (edgeItem != nullptr) {
-        _inEdgeItems.removeAll(edgeItem);
-        _outEdgeItems.removeAll(edgeItem);
+    // The object has already been partially destroyed so casting to the derived EdgeItem class is unsafe.
+    // We do this only to remove the EdgeItem from our internal lists.
+    const auto edgeItem_unsafe = static_cast<qan::EdgeItem*>(obj);
+    if (edgeItem_unsafe != nullptr)
+    {
+        _inEdgeItems.removeAll(edgeItem_unsafe);
+        _outEdgeItems.removeAll(edgeItem_unsafe);
     }
 }
 


### PR DESCRIPTION
Fixes #225.

@polinamials correctly identified the problem in the linked issue.
As edges get deleted, PortItems contain an ever growing list of invalid pointers to EdgeItems. 

The list of pointers is only used in NodeItem::updatePortsEdges() which appears to only get called when the VerticalDock qml element gets resized.